### PR TITLE
R Debug CRAN fixes

### DIFF
--- a/.github/workflows/OSX.yml
+++ b/.github/workflows/OSX.yml
@@ -106,8 +106,8 @@ jobs:
       shell: bash
       run: |
         python scripts/amalgamation.py
-        zip -j duckdb_cli-osx-amd64.zip build/release/duckdb
-        zip -j libduckdb-osx-amd64.zip build/release/src/libduckdb*.dylib src/amalgamation/duckdb.hpp src/include/duckdb.h
+        zip -j duckdb_cli-osx-universal.zip build/release/duckdb
+        zip -j libduckdb-osx-universal.zip build/release/src/libduckdb*.dylib src/amalgamation/duckdb.hpp src/include/duckdb.h
         python scripts/asset-upload-gha.py libduckdb-osx-universal.zip duckdb_cli-osx-universal.zip duckdb_jdbc-osx-universal.jar=build/release/tools/jdbc/duckdb_jdbc.jar
 
     - uses: actions/upload-artifact@v2

--- a/extension/icu/third_party/icu/common/locid.cpp
+++ b/extension/icu/third_party/icu/common/locid.cpp
@@ -299,7 +299,6 @@ Locale::Locale( const   char * newLanguage,
     else
     {
         UErrorCode status = U_ZERO_ERROR;
-        int32_t size = 0;
         int32_t lsize = 0;
         int32_t csize = 0;
         int32_t vsize = 0;
@@ -315,7 +314,6 @@ Locale::Locale( const   char * newLanguage,
                 setToBogus();
                 return;
             }
-            size = lsize;
         }
 
         CharString togo(newLanguage, lsize, status); // start with newLanguage
@@ -328,7 +326,6 @@ Locale::Locale( const   char * newLanguage,
                 setToBogus();
                 return;
             }
-            size += csize;
         }
 
         // _Variant
@@ -352,21 +349,6 @@ Locale::Locale( const   char * newLanguage,
             }
         }
 
-        if( vsize > 0 )
-        {
-            size += vsize;
-        }
-
-        // Separator rules:
-        if ( vsize > 0 )
-        {
-            size += 2;  // at least: __v
-        }
-        else if ( csize > 0 )
-        {
-            size += 1;  // at least: _v
-        }
-
         if ( newKeywords != NULL)
         {
             ksize = (int32_t)uprv_strlen(newKeywords);
@@ -374,7 +356,6 @@ Locale::Locale( const   char * newLanguage,
               setToBogus();
               return;
             }
-            size += ksize + 1;
         }
 
         //  NOW we have the full locale string..

--- a/scripts/jdbc_maven_deploy.py
+++ b/scripts/jdbc_maven_deploy.py
@@ -39,7 +39,7 @@ pom = '%s/duckdb_jdbc-%s.pom' % (staging_dir, release_version)
 sources_jar = '%s/duckdb_jdbc-%s-sources.jar' % (staging_dir, release_version)
 javadoc_jar = '%s/duckdb_jdbc-%s-javadoc.jar' % (staging_dir, release_version)
 
-combine_builds = ['linux-amd64', 'osx-amd64', 'windows-amd64']
+combine_builds = ['linux-amd64', 'osx-universal', 'windows-amd64']
 for build in combine_builds:
 	file_url = '%s/duckdb_jdbc-%s.jar' % (release_prefix, build)
 	# print(file_url)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,9 @@ if(NOT MSVC)
       "${CMAKE_CXX_FLAGS_DEBUG} -Wextra -Wno-unused-parameter -Wno-redundant-move"
   )
 endif()
+set(EXIT_TIME_DESTRUCTORS_WARNING FALSE)
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+  set(EXIT_TIME_DESTRUCTORS_WARNING TRUE)
   set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wexit-time-destructors")
 endif()
 

--- a/src/common/types/CMakeLists.txt
+++ b/src/common/types/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(${EXIT_TIME_DESTRUCTORS_WARNING})
+  set(CMAKE_CXX_FLAGS_DEBUG
+      "${CMAKE_CXX_FLAGS_DEBUG} -Wno-exit-time-destructors")
+endif()
+
 add_library_unity(
   duckdb_common_types
   OBJECT

--- a/src/common/types/vector_constants.cpp
+++ b/src/common/types/vector_constants.cpp
@@ -2,18 +2,6 @@
 
 namespace duckdb {
 
-// We disable Wexit-time-destructors here
-// Otherwise we get a warning about the two selection vectors (ZERO/INCREMENTAL_SELECTION_VECTOR)
-// While the SelectionVector does have a non-trivial destructor
-// This only does a memory de-allocation if the selection vectors own their data (i.e. selection_data is not null)
-// In the case of the FlatVector/ConstantVector, they point towards static regions of memory
-// Hence in this case these cause no problems, as the destructors are non-trivial but effectively nops
-#ifdef __clang__
-// commented out to satisfy R CMD check
-//#pragma clang diagnostic push
-//#pragma clang diagnostic ignored "-Wexit-time-destructors"
-#endif
-
 const SelectionVector *ConstantVector::ZeroSelectionVector() {
 	static const SelectionVector ZERO_SELECTION_VECTOR = SelectionVector((sel_t *)ConstantVector::ZERO_VECTOR);
 	return &ZERO_SELECTION_VECTOR;
@@ -25,10 +13,5 @@ const SelectionVector *FlatVector::IncrementalSelectionVector() {
 }
 
 const sel_t ConstantVector::ZERO_VECTOR[STANDARD_VECTOR_SIZE] = {0};
-
-#ifdef __clang__
-// commented out to satisfy R CMD check
-//#pragma clang diagnostic pop
-#endif
 
 } // namespace duckdb

--- a/src/main/extension/CMakeLists.txt
+++ b/src/main/extension/CMakeLists.txt
@@ -1,5 +1,9 @@
 include_directories(../../../third_party/httplib/)
 
+if(${EXIT_TIME_DESTRUCTORS_WARNING})
+  set(CMAKE_CXX_FLAGS_DEBUG
+      "${CMAKE_CXX_FLAGS_DEBUG} -Wno-exit-time-destructors")
+endif()
 add_library_unity(duckdb_main_extension OBJECT extension_helper.cpp
                   extension_install.cpp extension_load.cpp)
 set(ALL_OBJECT_FILES

--- a/third_party/httplib/httplib.hpp
+++ b/third_party/httplib/httplib.hpp
@@ -273,12 +273,6 @@ inline const unsigned char *ASN1_STRING_get0_data(const ASN1_STRING *asn1) {
 #include <brotli/encode.h>
 #endif
 
-#ifdef __clang__
-// commented out to satisfy R CMD check
-//#pragma clang diagnostic push
-//#pragma clang diagnostic ignored "-Wexit-time-destructors"
-#endif
-
 /*
  * Declaration
  */
@@ -8189,10 +8183,5 @@ inline SSL_CTX *Client::ssl_context() const {
 // ----------------------------------------------------------------------------
 
 } // namespace CPPHTTPLIB_NAMESPACE
-
-#ifdef __clang__
-// commented out to satisfy R CMD check
-//#pragma clang diagnostic pop
-#endif
 
 #endif // CPPHTTPLIB_HTTPLIB_H

--- a/third_party/libpg_query/include/pg_functions.hpp
+++ b/third_party/libpg_query/include/pg_functions.hpp
@@ -3,6 +3,8 @@
 #include <stdlib.h>
 #include <string>
 
+#define fprintf(...)
+
 #include "pg_definitions.hpp"
 
 #include "nodes/pg_list.hpp"

--- a/third_party/zstd/compress/zstd_compress_superblock.cpp
+++ b/third_party/zstd/compress/zstd_compress_superblock.cpp
@@ -410,16 +410,10 @@ static size_t ZSTD_seqDecompressedSize(seqStore_t const* seqStore, const seqDef*
     const seqDef* const send = sequences + nbSeq;
     const seqDef* sp = sstart;
     size_t matchLengthSum = 0;
-    size_t litLengthSum = 0;
     while (send-sp > 0) {
         ZSTD_sequenceLength const seqLen = ZSTD_getSequenceLength(seqStore, sp);
-        litLengthSum += seqLen.litLength;
         matchLengthSum += seqLen.matchLength;
         sp++;
-    }
-    assert(litLengthSum <= litSize);
-    if (!lastSequence) {
-        assert(litLengthSum == litSize);
     }
     return matchLengthSum + litSize;
 }

--- a/tools/rpkg/DESCRIPTION
+++ b/tools/rpkg/DESCRIPTION
@@ -56,6 +56,8 @@ Suggests:
     dbplyr,
     nycflights13,
     testthat,
+    tibble,
+    vctrs,
     withr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)

--- a/tools/rpkg/R/Result.R
+++ b/tools/rpkg/R/Result.R
@@ -46,7 +46,7 @@ duckdb_execute <- function(res) {
 
 duckdb_post_execute <- function(res, out) {
   if (!res@arrow) {
-    out <- list_to_df(out)
+    stopifnot(is.data.frame(out))
 
     if (!res@stmt_lst$type %in% c("SELECT", "EXPLAIN")) {
       res@env$rows_affected <- sum(as.numeric(out[[1]]))
@@ -56,15 +56,6 @@ duckdb_post_execute <- function(res, out) {
   }
 
   out
-}
-
-list_to_df <- function(x) {
-  if (is.data.frame(x)) {
-    return(x)
-  }
-  attr(x, "row.names") <- c(NA_integer_, -length(x[[1]]))
-  class(x) <- c( "data.frame")
-  x
 }
 
 # as per is.integer documentation

--- a/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
+++ b/tools/rpkg/R/backend-dbplyr__duckdb_connection.R
@@ -11,17 +11,11 @@
 #' library(dplyr, warn.conflicts = FALSE)
 #' con <- DBI::dbConnect(duckdb::duckdb(), path = ":memory:")
 #'
-#' x <- tibble(txt = c("why", "video", "cross", "extra", "deal", "authority"))
-#' dbx <- copy_to(con, x, overwrite = TRUE)
+#' dbiris <- copy_to(con, iris, overwrite = TRUE)
 #'
-#' # x %>% mutate(a = stringr::str_pad(txt, 10, side = "both", pad = ">"))
-#' dbx %>% mutate(a = str_pad(txt, 10, side = "both", pad = ">"))
-#'
-#' # x %>% mutate(a = stringr::str_replace_all(txt, "[aeiou]", "?"))
-#' dbx %>% mutate(a = str_replace_all(txt, "[aeiou]", "?"))
+#' dbiris %>% select(Petal.Length, Petal.Width) %>% filter(Petal.Length > 1.5) %>% head(5)
 #'
 #' DBI::dbDisconnect(con, shutdown = TRUE)
-#' duckdb::duckdb_shutdown(duckdb::duckdb())
 NULL
 
 #' Connection object for simulation of the SQL generation without actual database.

--- a/tools/rpkg/R/dbBind__duckdb_result.R
+++ b/tools/rpkg/R/dbBind__duckdb_result.R
@@ -30,3 +30,12 @@ dbBind__duckdb_result <- function(res, params, ...) {
 #' @rdname duckdb_result-class
 #' @export
 setMethod("dbBind", "duckdb_result", dbBind__duckdb_result)
+
+list_to_df <- function(x) {
+  if (is.data.frame(x)) {
+    return(x)
+  }
+  attr(x, "row.names") <- c(NA_integer_, -NROW(x[[1]]))
+  class(x) <- "data.frame"
+  x
+}

--- a/tools/rpkg/R/dbFetch__duckdb_result.R
+++ b/tools/rpkg/R/dbFetch__duckdb_result.R
@@ -6,6 +6,14 @@ dbFetch__duckdb_result <- function(res, n = -1, ...) {
   if (!res@env$open) {
     stop("result set was closed")
   }
+
+  if (res@arrow) {
+    if (n != -1) {
+      stop("Cannot dbFetch() an Arrow result unless n = -1")
+    }
+    return(as.data.frame(duckdb::duckdb_fetch_arrow(res)))
+  }
+
   if (is.null(res@env$resultset)) {
     stop("Need to call `dbBind()` before `dbFetch()`")
   }
@@ -30,10 +38,6 @@ dbFetch__duckdb_result <- function(res, n = -1, ...) {
   if (res@stmt_lst$type != "SELECT") {
     warning("Should not call dbFetch() on results that do not come from SELECT")
     return(data.frame())
-  }
-
-  if (res@arrow) {
-    stop("Cannot dbFetch() an Arrow result")
   }
 
   timezone_out <- res@connection@timezone_out

--- a/tools/rpkg/man/backend-duckdb.Rd
+++ b/tools/rpkg/man/backend-duckdb.Rd
@@ -27,9 +27,6 @@ dbx <- copy_to(con, x, overwrite = TRUE)
 # x \%>\% mutate(a = stringr::str_pad(txt, 10, side = "both", pad = ">"))
 dbx \%>\% mutate(a = str_pad(txt, 10, side = "both", pad = ">"))
 
-# x \%>\% mutate(a = stringr::str_replace_all(txt, "[aeiou]", "?"))
-dbx \%>\% mutate(a = str_replace_all(txt, "[aeiou]", "?"))
-
 DBI::dbDisconnect(con, shutdown = TRUE)
 duckdb::duckdb_shutdown(duckdb::duckdb())
 }

--- a/tools/rpkg/rconfigure.py
+++ b/tools/rpkg/rconfigure.py
@@ -108,3 +108,16 @@ else:
 # now write it to the output Makevars
 with open_utf8(os.path.join('src', 'Makevars'), 'w+') as f:
     f.write(text)
+
+ # same dance for Windows
+ # read Makevars.in and replace the {{ SOURCES }} and {{ INCLUDES }} macros
+ with open_utf8(os.path.join('src', 'Makevars.in'), 'r') as f:
+     text = f.read()
+
+ text = text.replace('{{ SOURCES }}', object_list)
+ text = text.replace('{{ INCLUDES }}', include_list)
+ text = text.replace('{{ LINK_FLAGS }}', "-lws2_32")
+
+ # now write it to the output Makevars
+ with open_utf8(os.path.join('src', 'Makevars.win'), 'w+') as f:
+     f.write(text)

--- a/tools/rpkg/rconfigure.py
+++ b/tools/rpkg/rconfigure.py
@@ -109,15 +109,15 @@ else:
 with open_utf8(os.path.join('src', 'Makevars'), 'w+') as f:
     f.write(text)
 
- # same dance for Windows
- # read Makevars.in and replace the {{ SOURCES }} and {{ INCLUDES }} macros
- with open_utf8(os.path.join('src', 'Makevars.in'), 'r') as f:
-     text = f.read()
+# same dance for Windows
+# read Makevars.in and replace the {{ SOURCES }} and {{ INCLUDES }} macros
+with open_utf8(os.path.join('src', 'Makevars.in'), 'r') as f:
+    text = f.read()
 
- text = text.replace('{{ SOURCES }}', object_list)
- text = text.replace('{{ INCLUDES }}', include_list)
- text = text.replace('{{ LINK_FLAGS }}', "-lws2_32")
+text = text.replace('{{ SOURCES }}', object_list)
+text = text.replace('{{ INCLUDES }}', include_list)
+text = text.replace('{{ LINK_FLAGS }}', "-lws2_32")
 
- # now write it to the output Makevars
- with open_utf8(os.path.join('src', 'Makevars.win'), 'w+') as f:
-     f.write(text)
+# now write it to the output Makevars
+with open_utf8(os.path.join('src', 'Makevars.win'), 'w+') as f:
+    f.write(text)

--- a/tools/rpkg/src/Makevars.in
+++ b/tools/rpkg/src/Makevars.in
@@ -1,3 +1,4 @@
+CXX_STD = CXX11
 PKG_CPPFLAGS = -Iinclude -I../inst/include -DDUCKDB_DISABLE_PRINT {{ INCLUDES }}
 OBJECTS=database.o connection.o statement.o register.o relational.o scan.o utils.o altrep.o types.o cpp11.o {{ SOURCES }}
 PKG_LIBS={{ LINK_FLAGS }}

--- a/tools/rpkg/src/include/rapi.hpp
+++ b/tools/rpkg/src/include/rapi.hpp
@@ -99,6 +99,7 @@ struct RStrings {
 	SEXP UTC_str; // Rf_mkString
 	SEXP Date_str;
 	SEXP factor_str;
+	SEXP dataframe_str;
 	SEXP difftime_str;
 	SEXP secs_str;
 	SEXP arrow_str; // StringsToSexp

--- a/tools/rpkg/src/utils.cpp
+++ b/tools/rpkg/src/utils.cpp
@@ -54,7 +54,7 @@ RStrings::RStrings() {
 	R_PreserveObject(strings);
 	MARK_NOT_MUTABLE(strings);
 
-	SEXP chars = r.Protect(Rf_allocVector(VECSXP, 7));
+	SEXP chars = r.Protect(Rf_allocVector(VECSXP, 8));
 	SET_VECTOR_ELT(chars, 0, UTC_str = Rf_mkString("UTC"));
 	SET_VECTOR_ELT(chars, 1, Date_str = Rf_mkString("Date"));
 	SET_VECTOR_ELT(chars, 2, difftime_str = Rf_mkString("difftime"));
@@ -62,6 +62,7 @@ RStrings::RStrings() {
 	SET_VECTOR_ELT(chars, 4, arrow_str = Rf_mkString("arrow"));
 	SET_VECTOR_ELT(chars, 5, POSIXct_POSIXt_str = StringsToSexp({"POSIXct", "POSIXt"}));
 	SET_VECTOR_ELT(chars, 6, factor_str = Rf_mkString("factor"));
+	SET_VECTOR_ELT(chars, 7, dataframe_str = Rf_mkString("data.frame"));
 
 	R_PreserveObject(chars);
 	MARK_NOT_MUTABLE(chars);

--- a/tools/rpkg/tests/testthat/test-DBItest.R
+++ b/tools/rpkg/tests/testthat/test-DBItest.R
@@ -1,4 +1,3 @@
-library("testthat")
 skip_on_cran()
 
 # remotes::install_github("r-dbi/dblog")

--- a/tools/rpkg/tests/testthat/test_arrow.R
+++ b/tools/rpkg/tests/testthat/test_arrow.R
@@ -15,17 +15,17 @@
 # specific language governing permissions and limitations
 # under the License.
 
-library(arrow, warn.conflicts = FALSE)
-library(dplyr, warn.conflicts = FALSE)
-library(duckdb)
-library("testthat")
-library("DBI")
 skip_on_cran()
 skip_on_os("windows")
+skip_if_not_installed("dbplyr")
+skip_if_not_installed("dplyr")
 skip_if_not_installed("arrow", "5.0.0")
 # Skip if parquet is not a capability as an indicator that Arrow is fully installed.
 skip_if_not(arrow::arrow_with_parquet(), message = "The installed Arrow is not fully featured, skipping Arrow integration tests")
-skip_if_not_installed("dbplyr")
+
+library("DBI")
+library("duckdb")
+library("dplyr")
 
 example_data <- dplyr::tibble(
   int = c(1:3, NA_integer_, 5:10),

--- a/tools/rpkg/tests/testthat/test_arrow.R
+++ b/tools/rpkg/tests/testthat/test_arrow.R
@@ -23,10 +23,11 @@ skip_if_not_installed("arrow", "5.0.0")
 # Skip if parquet is not a capability as an indicator that Arrow is fully installed.
 skip_if_not(arrow::arrow_with_parquet(), message = "The installed Arrow is not fully featured, skipping Arrow integration tests")
 
+library(arrow, warn.conflicts = FALSE)
+library(dplyr, warn.conflicts = FALSE)
+library(duckdb)
+library("testthat")
 library("DBI")
-library("duckdb")
-library("dplyr")
-library("arrow")
 
 example_data <- dplyr::tibble(
   int = c(1:3, NA_integer_, 5:10),

--- a/tools/rpkg/tests/testthat/test_arrow.R
+++ b/tools/rpkg/tests/testthat/test_arrow.R
@@ -26,6 +26,7 @@ skip_if_not(arrow::arrow_with_parquet(), message = "The installed Arrow is not f
 library("DBI")
 library("duckdb")
 library("dplyr")
+library("arrow")
 
 example_data <- dplyr::tibble(
   int = c(1:3, NA_integer_, 5:10),

--- a/tools/rpkg/tests/testthat/test_arrow_stream.R
+++ b/tools/rpkg/tests/testthat/test_arrow_stream.R
@@ -1,9 +1,9 @@
-library("testthat")
-library("DBI")
 skip_on_cran()
 skip_on_os("windows")
 skip_if_not_installed("arrow", "5.0.0")
 
+library("testthat")
+library("DBI")
 library("arrow", warn.conflicts = FALSE)
 library("dplyr", warn.conflicts = FALSE)
 library("duckdb")

--- a/tools/rpkg/tests/testthat/test_config_keyvalue.R
+++ b/tools/rpkg/tests/testthat/test_config_keyvalue.R
@@ -1,6 +1,3 @@
-library("testthat")
-library("DBI")
-
 test_that("configuration key value pairs work as expected", {
 
   # setting nothing or empty list should work

--- a/tools/rpkg/tests/testthat/test_factor.R
+++ b/tools/rpkg/tests/testthat/test_factor.R
@@ -1,6 +1,3 @@
-library("DBI")
-library("testthat")
-
 test_that("factors can be round tripped", {
   con <- dbConnect(duckdb::duckdb())
   on.exit(dbDisconnect(con, shutdown = TRUE))

--- a/tools/rpkg/tests/testthat/test_fetch_arrow.R
+++ b/tools/rpkg/tests/testthat/test_fetch_arrow.R
@@ -1,6 +1,3 @@
-library("testthat")
-library("DBI")
-
 skip_on_cran()
 skip_on_os("windows")
 skip_if_not_installed("arrow", "5.0.0")

--- a/tools/rpkg/tests/testthat/test_register_arrow.R
+++ b/tools/rpkg/tests/testthat/test_register_arrow.R
@@ -1,11 +1,10 @@
-library("testthat")
-library("DBI")
-
 skip_on_cran()
 skip_on_os("windows")
 skip_if_not_installed("arrow", "5.0.0")
 # Skip if parquet is not a capability as an indicator that Arrow is fully installed.
 skip_if_not(arrow::arrow_with_parquet(), message = "The installed Arrow is not fully featured, skipping Arrow integration tests")
+
+library("arrow")
 
 test_that("duckdb_register_arrow() works", {
   con <- dbConnect(duckdb::duckdb())

--- a/tools/rpkg/tests/testthat/test_struct.R
+++ b/tools/rpkg/tests/testthat/test_struct.R
@@ -1,0 +1,110 @@
+test_that("structs can be read", {
+  skip_if_not_installed("vctrs")
+
+  con <- dbConnect(duckdb::duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  res <- dbGetQuery(con, "SELECT {'x': 100, 'y': 'hello', 'z': 3.14} AS s")
+  expect_equal(res, vctrs::data_frame(
+    s = vctrs::data_frame(x = 100L, y = "hello", z = 3.14)
+  ))
+
+  res <- dbGetQuery(con, "SELECT 1 AS n, {'x': 100, 'y': 'hello', 'z': 3.14} AS s")
+  expect_equal(res, vctrs::data_frame(
+    n = 1L,
+    s = vctrs::data_frame(x = 100L, y = "hello", z = 3.14)
+  ))
+
+  res <- dbGetQuery(con, "values (100, {'x': 100}), (200, {'x': 200}), (300, NULL)")
+  expect_equal(res, vctrs::data_frame(
+    col0 = c(100L, 200L, 300L),
+    col1 = vctrs::data_frame(x = c(100L, 200L, NA))
+  ))
+
+  res <- dbGetQuery(con, "values ('a', {'x': 100, 'y': {'a': 1, 'b': 2}}), ('b', {'x': 200, y: NULL}), ('c', NULL)")
+  expect_equal(res, vctrs::data_frame(
+    col0 = c("a", "b", "c"),
+    col1 = vctrs::data_frame(
+      x = c(100L, 200L, NA),
+      y = vctrs::data_frame(a = c(1L, NA, NA), b = c(2L, NA, NA))
+    )
+  ))
+
+  res <- dbGetQuery(con, "select 100 AS other, [{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}] AS s")
+  expect_equal(res, vctrs::data_frame(
+    other = 100L,
+    s = list(
+      vctrs::data_frame(x = c(1L, 2L), y = c("a", "b"))
+    )
+  ))
+
+  res <- dbGetQuery(con, "values ([{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}]), ([]), ([{'x': 1, 'y': 'a'}])")
+  expect_equal(res, vctrs::data_frame(
+    col0 = list(
+      vctrs::data_frame(x = c(1L, 2L), y = c("a", "b")),
+      vctrs::data_frame(x = integer(0), y = character(0)),
+      vctrs::data_frame(x = 1L, y = "a")
+    )
+  ))
+})
+
+test_that("structs give the same results via Arrow", {
+  skip_if_not_installed("vctrs")
+  skip_if_not_installed("tibble")
+  skip_if_not_installed("arrow")
+
+  con <- dbConnect(duckdb::duckdb())
+  on.exit(dbDisconnect(con, shutdown = TRUE))
+
+  res <- dbGetQuery(con, "SELECT {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    s = tibble::tibble(x = 100L, y = "hello", z = 3.14)
+  ))
+
+  res <- dbGetQuery(con, "SELECT 1 AS n, {'x': 100, 'y': 'hello', 'z': 3.14} AS s", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    n = 1L,
+    s = tibble::tibble(x = 100L, y = "hello", z = 3.14)
+  ))
+
+  res <- dbGetQuery(con, "values (100, {'x': 100}), (200, {'x': 200}), (300, NULL)", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    col0 = c(100L, 200L, 300L),
+    col1 = tibble::tibble(x = c(100L, 200L, NA))
+  ))
+
+  res <- dbGetQuery(con, "values ('a', {'x': 100, 'y': {'a': 1, 'b': 2}}), ('b', {'x': 200, y: NULL}), ('c', NULL)", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    col0 = c("a", "b", "c"),
+    col1 = tibble::tibble(
+      x = c(100L, 200L, NA),
+      y = tibble::tibble(a = c(1L, NA, NA), b = c(2L, NA, NA))
+    )
+  ))
+
+  res <- dbGetQuery(con, "select 100 AS other, [{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}] AS s", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    other = 100L,
+    s = vctrs::new_list_of(
+      list(
+        tibble::tibble(x = c(1L, 2L), y = c("a", "b"))
+      ),
+      ptype = tibble::tibble(x = integer(), y = character()),
+      class = "arrow_list"
+    )
+  ))
+
+  res <- dbGetQuery(con, "values ([{'x': 1, 'y': 'a'}, {'x': 2, 'y': 'b'}]), ([]), ([{'x': 1, 'y': 'a'}])", arrow = TRUE)
+  expect_equal(res, tibble::tibble(
+    col0 = vctrs::new_list_of(
+      list(
+        tibble::tibble(x = c(1L, 2L), y = c("a", "b")),
+        tibble::tibble(x = integer(0), y = character(0)),
+        tibble::tibble(x = 1L, y = "a")
+      ),
+      ptype = tibble::tibble(x = integer(), y = character()),
+      class = "arrow_list"
+    )
+  ))
+})
+


### PR DESCRIPTION
* Remove -Wexit-time-destructor pragmas, and instead disable these warnings in specific compilation units using CMake
* Several other MacOS warning fixes
* Many CRAN fixes from Hannes (see [here](https://github.com/hannes/duckdb/commit/d2cc764a70ef1d0ca96f44da36e9d6338349cda7))